### PR TITLE
add traces to stdio (phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ you need a free acount in https://app.alpaca.markets/signup for us to fetch mark
 to get your image onto dev clusters's registry use:
 ```
 docker pull redis:6.2-alpine 
-kind load docker-image  redis:6.2-alpine -n trader-cluster
+kind load docker-image -n trader-cluster redis:6.2-alpine
+
+#dnsutils:
+docker pull registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
+ kind load docker-image -n trader-cluster registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
 ```
 
 # trubleshoot:

--- a/Tiltfile
+++ b/Tiltfile
@@ -38,5 +38,5 @@ k8s_resource(
   port_forwards=5000,
   resource_deps=[
     'trading-robot-bin',
-  ]
+  ],
 )

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -7,10 +7,19 @@ COPY . /var/flasksite/
 WORKDIR /var/flasksite/
 
 RUN pip3 install -r requirements.txt
+RUN opentelemetry-bootstrap --action=install
+
 
 EXPOSE 5000
 
+# TODO: move to k8s config-map
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
 
-CMD ["flask", "run"]
+#ENV OTEL_RESOURCE_ATTRIBUTES=service.name=flaskApp 
+#ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+#ENV OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+
+# CMD ["flask", "run"]
+CMD [ "opentelemetry-instrument", "--traces_exporter",  "console", "--service_name", "web-ui", "flask", "run" ]

--- a/sample/requirements.txt
+++ b/sample/requirements.txt
@@ -1,7 +1,20 @@
-flask
+#redis:
 redis==4.3.4
-alpaca-trade-api
-fakeredis
+fakeredis==2.24.1
+
+# numerical
 numpy
-pandas
-ta
+alpaca-trade-api==3.2.0
+pandas==2.2.2
+ta==0.11.0
+
+# web:
+flask==3.0.3
+opentelemetry-api==1.26.0
+opentelemetry-distro==0.47b0
+opentelemetry-instrumentation-flask==0.47b0
+opentelemetry-instrumentation==0.47b0
+opentelemetry-semantic-conventions==0.47b0
+opentelemetry-sdk==1.26.0
+opentelemetry-exporter-otlp-proto-http==1.26.0
+opentelemetry-exporter-otlp==1.26.0


### PR DESCRIPTION
with this code integrated - you will start getting traces printed to stdout of the service.
Next PR i'll add a collector to display those on victoria-metrics

expected results - see somthing like this in web-ui logs:
```
{
    "name": "GET /add-stock",
    "context": {
        "trace_id": "0x4eee680288b179a2d0fe57c632f7844b",
        "span_id": "0xc370e1d23536272d",
        "trace_state": "[]"
    },
    "kind": "SpanKind.SERVER",
    "parent_id": null,
    "start_time": "2024-08-27T19:01:16.053490Z",
    "end_time": "2024-08-27T19:01:16.058814Z",
    "status": {
        "status_code": "UNSET"
    },
    "attributes": {
        "http.method": "GET",
        "http.server_name": "0.0.0.0",
        "http.scheme": "http",
        "net.host.name": "localhost:5000",
        "http.host": "localhost:5000",
        "net.host.port": 5000,
        "http.target": "/add-stock",
        "net.peer.ip": "127.0.0.1",
        "net.peer.port": 50736,
        "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
        "http.flavor": "1.1",
        "http.route": "/add-stock",
        "http.status_code": 200
    },
    "events": [],
    "links": [],
    "resource": {
        "attributes": {
            "telemetry.sdk.language": "python",
            "telemetry.sdk.name": "opentelemetry",
            "telemetry.sdk.version": "1.26.0",
            "service.name": "web-ui",
            "telemetry.auto.version": "0.47b0"
        },
        "schema_url": ""
    }
}
```